### PR TITLE
Improve performance and fix metrics modal

### DIFF
--- a/src/jhi-components.ts
+++ b/src/jhi-components.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CapitalizePipe, FilterPipe, KeysPipe, OrderByPipe, TruncateCharactersPipe, TruncateWordsPipe} from './pipe';
+import { CapitalizePipe, FilterPipe, KeysPipe, OrderByPipe, PureFilterPipe, TruncateCharactersPipe, TruncateWordsPipe} from './pipe';
 import { MaxbytesValidatorDirective, MinbytesValidatorDirective,
     ShowValidationDirective, JhiSortDirective, JhiSortByDirective } from './directive';
 import { JhiItemCountComponent } from './component';
@@ -24,6 +24,7 @@ export const JHI_PIPES = [
     FilterPipe,
     KeysPipe,
     OrderByPipe,
+    PureFilterPipe,
     TruncateCharactersPipe,
     TruncateWordsPipe
 ];

--- a/src/pipe/filter.pipe.ts
+++ b/src/pipe/filter.pipe.ts
@@ -15,7 +15,7 @@
  */
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'filter', pure: false })
+@Pipe({ name: 'filter', pure: true })
 export class FilterPipe implements PipeTransform {
 
     private filterByStringAndField(filter, field) {

--- a/src/pipe/filter.pipe.ts
+++ b/src/pipe/filter.pipe.ts
@@ -15,7 +15,7 @@
  */
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({ name: 'filter', pure: true })
+@Pipe({ name: 'filter', pure: false })
 export class FilterPipe implements PipeTransform {
 
     private filterByStringAndField(filter, field) {

--- a/src/pipe/index.ts
+++ b/src/pipe/index.ts
@@ -2,5 +2,6 @@ export * from './truncate-characters.pipe';
 export * from './truncate-words.pipe';
 export * from './order-by.pipe';
 export * from './filter.pipe';
+export * from './pure-filter.pipe';
 export * from './capitalize.pipe';
 export * from './keys.pipe';

--- a/src/pipe/pure-filter.pipe.ts
+++ b/src/pipe/pure-filter.pipe.ts
@@ -1,0 +1,5 @@
+import { Pipe } from '@angular/core';
+import { FilterPipe } from './filter.pipe';
+
+@Pipe({ name: 'pureFilter' })
+export class PureFilterPipe extends FilterPipe {}

--- a/src/pipe/pure-filter.pipe.ts
+++ b/src/pipe/pure-filter.pipe.ts
@@ -1,5 +1,9 @@
-import { Pipe } from '@angular/core';
+import { Pipe, PipeTransform } from '@angular/core';
 import { FilterPipe } from './filter.pipe';
 
 @Pipe({ name: 'pureFilter' })
-export class PureFilterPipe extends FilterPipe {}
+export class PureFilterPipe extends FilterPipe implements PipeTransform {
+    transform(input: Array<any>, filter: string, field: string): any {
+        return super.transform(input, filter, field);
+    }
+}


### PR DESCRIPTION
Hello,
This change improves our pipe performance by a lot (it is called only when theres a change to the input) and it fixes the modal screen.
Explanation  of the bug : When you open the metrics modal and filter by runnable (or any buttons) the list was correctly filtered but you couldn't click on "show stacktrace" (it had no effect).

Now it is resolved 
Edit : I didn't test on every screen that used this pipe, can you not merge this right now pls ?
Besides that was there any reason to use impure pipes ? (We are changing object reference every time we use it so I don't see the reason)