### PR TITLE
Fix alert close on timeout

### DIFF
--- a/src/service/alert.service.ts
+++ b/src/service/alert.service.ts
@@ -121,7 +121,7 @@ export class AlertService {
     }
 
     closeAlert(id: number, extAlerts?: Alert[]): any {
-        let thisAlerts: Alert[] = extAlerts ? extAlerts : this.alerts;
+        let thisAlerts: Alert[] = (extAlerts && extAlerts.length > 0) ? extAlerts : this.alerts;
         return this.closeAlertByIndex(thisAlerts.map(e => e.id).indexOf(id), thisAlerts);
     }
 

--- a/tests/service/alert.service.spec.ts
+++ b/tests/service/alert.service.spec.ts
@@ -37,7 +37,15 @@ describe('Alert service test', () => {
                     provide: AlertService, useFactory: mockAlertService, deps: [Sanitizer]
                 }]
             });
+            // Make sure we can install mock clock
+            jasmine.clock().uninstall();
+            jasmine.clock().install();
         });
+
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
 
         it('should produce a proper alert object and fetch it', inject([AlertService], (service: AlertService) => {
             expect(service.addAlert({
@@ -116,6 +124,16 @@ describe('Alert service test', () => {
                 msg: 'Hello Jhipster info',
                 id: 0
             }));
+        }));
+
+        it('should close an alert on timeout correctly', inject([AlertService], (service: AlertService) => {
+            service.info('Hello Jhipster info');
+
+            expect(service.get().length).toBe(1);
+
+            jasmine.clock().tick(6000); // increment clock 6000 ms.
+
+            expect(service.get().length).toBe(0);
         }));
 
         it('should clear alerts', inject([AlertService], (service: AlertService) => {


### PR DESCRIPTION
I wrote a unit test showing that an alert is not removed from alertsarray on timeout.

I think there is an ambiguity about extAlerts, I don't understand its goal because when adding a new alert added to extAlerts and so it cannot be removed on close.