### PR TITLE
Check for null input in function toDate

### DIFF
--- a/src/service/date-util.service.ts
+++ b/src/service/date-util.service.ts
@@ -69,7 +69,7 @@ export class DateUtils {
 
     // TODO Change this method when moving from datetime-local input to NgbDatePicker
     toDate(date: any): Date {
-        if (date === undefined) {
+        if (date === undefined || date === null) {
             return null;
         }
         let dateParts = date.split(/\D+/);

--- a/tests/service/date-util.service.spec.ts
+++ b/tests/service/date-util.service.spec.ts
@@ -74,7 +74,7 @@ describe('Date Utils service test', () => {
         it('should toDate convert datetime-local to date', inject([DateUtils], (service: DateUtils) => {
             let date = '2016-05-10T23:20:50.52';
             let dateValue = service.toDate(date);
-            expect(dateValue).toEqual(new Date('Fri May 10 2016 23:20:00 GMT+0200 (CEST)'));
+            expect(dateValue).toEqual(new Date('2016-05-10 23:20'));
             expect(dateValue instanceof Date).toBe(true);
         }));
 

--- a/tests/service/date-util.service.spec.ts
+++ b/tests/service/date-util.service.spec.ts
@@ -70,5 +70,26 @@ describe('Date Utils service test', () => {
             let dateValue = service.convertLocalDateToServer({year: 2016, month: 5, day: 10}, 'yyyy');
             expect(dateValue).toEqual('2016');
         }));
+
+        it('should toDate convert datetime-local to date', inject([DateUtils], (service: DateUtils) => {
+            let date = '2016-05-10T23:20:50.52';
+            let dateValue = service.toDate(date);
+            expect(dateValue).toEqual(new Date('Fri May 10 2016 23:20:00 GMT+0200 (CEST)'));
+            expect(dateValue instanceof Date).toBe(true);
+        }));
+
+        it('should toDate to null when input is undefined', inject([DateUtils], (service: DateUtils) => {
+            let date = undefined;
+            let dateValue = service.toDate(date);
+            expect(dateValue).toBeNull;
+            expect(dateValue instanceof Date).toBe(false);
+        }));
+
+        it('should toDate to null when input is null', inject([DateUtils], (service: DateUtils) => {
+            let date = null;
+            let dateValue = service.toDate(date);
+            expect(dateValue).toBeNull;
+            expect(dateValue instanceof Date).toBe(false);
+        }));
     });
 });


### PR DESCRIPTION
Function `toDate` in `DateUtil` is checking only for `undefined` values. Empty properties in data models have `null` values instead of `undefined`.

```typescript
// Generated update function in Entity service
update(application: Application): Observable<Application> {
    let copy: Application = Object.assign({}, application);

    // deactivatedDate is null. This behavior throws an error in function toDate.
    copy.deactivatedDate = this.dateUtils.toDate(application.deactivatedDate);
    return this.http.put(this.resourceUrl, copy).map((res: Response) => {
        return res.json();
    });
}
```