### PR TITLE
Fix assigning values to read-only string object

### DIFF
--- a/src/language/translate-partial-loader.ts
+++ b/src/language/translate-partial-loader.ts
@@ -47,7 +47,7 @@ export class TranslatePartialLoader implements TranslateLoader {
             this.http.get(`${this.prefix}/${lang}/${part}${this.suffix}`).subscribe((res) => {
                 let responseObj = res.json();
                 Object.keys(responseObj).forEach(key => {
-                    if (!combinedObject[key]) {
+                    if (!combinedObject[key] || typeof(combinedObject[key]) === 'string') {
                         combinedObject[key] = responseObj[key];
                     } else {
                         Object.assign(combinedObject[key], responseObj[key]);


### PR DESCRIPTION
This happened with global.footer, which is a string - a read-only object in javascript.

( https://github.com/jhipster/generator-jhipster/pull/5689 )