### PR TITLE
Fixed Angular 2+ hardcoded values

### DIFF
--- a/src/component/jhi-item-count.component.ts
+++ b/src/component/jhi-item-count.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Component, Input } from '@angular/core';
+import { ConfigService } from '../config.service';
 
 /**
  * A component that will take care of item count statistics of a pagination.
@@ -21,11 +22,16 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'jhi-item-count',
     template: `
-        <div class="info jhi-item-count">
+        <div *ngIf="i18nEnabled; else noI18n" class="info jhi-item-count" 
+            jhiTranslate="global.item-count" 
+            translateValues="{{i18nValues()}}"
+            [attr.translateValues]="i18nValues()">  /* [attr.translateValues] is used to get entire values in tests */
+        </div>
+        <ng-template #noI18n class="info jhi-item-count">
             Showing {{((page - 1) * itemsPerPage) == 0 ? 1 : ((page - 1) * itemsPerPage + 1)}} -
             {{(page * itemsPerPage) < total ? (page * itemsPerPage) : total}}
             of {{total}} items.
-        </div>`
+        </ng-template>`
 })
 export class JhiItemCountComponent {
 
@@ -44,5 +50,22 @@ export class JhiItemCountComponent {
     */
     @Input() itemsPerPage: number;
 
-    constructor() {}
+    /**
+     * True if the generated application use i18n
+     */
+    i18nEnabled: boolean;
+
+    /**
+     * "translate-values" JSON of the template
+     */
+    i18nValues(): string {
+        const first = ((this.page - 1) * this.itemsPerPage) === 0 ? 1 : ((this.page - 1) * this.itemsPerPage + 1);
+        const second = (this.page * this.itemsPerPage) < this.total ? (this.page * this.itemsPerPage) : this.total;
+        return '{first: \'' + first + '\', second: \'' + second + '\', total: \'' + this.total + '\'}';
+    }
+
+    constructor(config: ConfigService) {
+        this.i18nEnabled = config.CONFIG_OPTIONS.i18nEnabled;
+    }
+
 }

--- a/tests/component/jhi-item-count.component.spec.ts
+++ b/tests/component/jhi-item-count.component.spec.ts
@@ -15,9 +15,9 @@
  */
 
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { TranslateModule } from 'ng2-translate';
 import { JhiItemCountComponent } from '../../src/component/jhi-item-count.component';
 import { JhiTranslateComponent } from '../../src/language/jhi-translate.directive';
-import { TranslateModule } from 'ng2-translate';
 import { ConfigService } from '../../src/config.service';
 
 function getElementHtml(element: ComponentFixture<JhiItemCountComponent>): string {

--- a/tests/component/jhi-item-count.component.spec.ts
+++ b/tests/component/jhi-item-count.component.spec.ts
@@ -16,10 +16,22 @@
 
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { JhiItemCountComponent } from '../../src/component/jhi-item-count.component';
-
+import { JhiTranslateComponent } from '../../src/language/jhi-translate.directive';
+import { TranslateModule } from 'ng2-translate';
+import { ConfigService } from '../../src/config.service';
 
 function getElementHtml(element: ComponentFixture<JhiItemCountComponent>): string {
-    return element.nativeElement.querySelector('.jhi-item-count').innerHTML.trim();
+    const res = element.nativeElement.querySelector('.jhi-item-count');
+    return (res && res.innerHTML) ? res.innerHTML.trim() : '';
+}
+
+function getElementAttribute(element: ComponentFixture<JhiItemCountComponent>, value: string): string {
+    let res = element.nativeElement.querySelector('.jhi-item-count');
+    if (res && res.attributes) {
+        res = res.attributes.getNamedItem(value);
+        return (res && res.value) ? res.value.trim() : '';
+    }
+    return '';
 }
 
 describe('JhiItemCountComponent test', () => {
@@ -29,7 +41,15 @@ describe('JhiItemCountComponent test', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [JhiItemCountComponent]
+            declarations: [JhiItemCountComponent, JhiTranslateComponent],
+            imports: [TranslateModule.forRoot()],
+            providers: [
+                JhiItemCountComponent,
+                {
+                    provide: ConfigService,
+                    useValue: new ConfigService({defaultI18nLang: 'en', i18nEnabled: true})
+                }
+            ]
         }).compileComponents();
     }));
 
@@ -51,16 +71,28 @@ describe('JhiItemCountComponent test', () => {
             comp.total = 100;
             fixture.detectChanges();
 
-            expect(getElementHtml(fixture)).toBe(`Showing 1 -
-            10
-            of 100 items.`);
-
+            getElementHtml(fixture);
+            expect(getElementAttribute(fixture, 'translateValues')).toBe(`{first: '1', second: '10', total: '100'}`);
             comp.page = 2;
             fixture.detectChanges();
 
-            expect(getElementHtml(fixture)).toBe(`Showing 11 -
-            20
-            of 100 items.`);
+            getElementHtml(fixture);
+            expect(getElementAttribute(fixture, 'translateValues')).toBe(`{first: '11', second: '20', total: '100'}`);
+        });
+
+        it('should not translate the content', () => {
+            comp.i18nEnabled = false;
+            comp.page = 1;
+            comp.itemsPerPage = 10;
+            comp.total = 100;
+            fixture.detectChanges();
+            expect(getElementAttribute(fixture, 'translateValues')).toBe(``);
+            expect(getElementHtml(fixture)).toBe(``);
+
+            comp.page = 2;
+            fixture.detectChanges();
+            expect(getElementAttribute(fixture, 'translateValues')).toBe(``);
+            expect(getElementHtml(fixture)).toBe(``);
         });
     });
 });


### PR DESCRIPTION
Fixed jhipster/generator-jhipster#5739, for the Angular 2 part.

For example, in Catalan and French :
![capture d ecran de 2017-05-22 12-04-55](https://cloud.githubusercontent.com/assets/11616517/26345870/8b99f7a2-3fa4-11e7-918c-3b1ee091eecd.png)
![capture d ecran de 2017-05-22 12-05-28](https://cloud.githubusercontent.com/assets/11616517/26345871/8b9ac42a-3fa4-11e7-897b-154cc7edf52f.png)

Without I18n : 
![capture d ecran de 2017-05-22 13-55-52](https://cloud.githubusercontent.com/assets/11616517/26345872/8b9cf042-3fa4-11e7-90c4-759901327e92.png)

**NOTE** : As I never worked on AngularJS, I may need some help to change the _webapp/app/components/util/jhi-item-count.directive.js_ file. 
After a discussion with @jdubois, there is no need to change the AngularJS code as it will probably be soon deprecated, and as nobody has mentionned this problem with AngularJS.

**NOTE 2** : New key in this PR jhipster/generator-jhipster#5821