### PR TITLE
Removed Angular warnings. (/!\ One of 2 for the moment)

### DIFF
--- a/src/interceptor/interceptable-http.ts
+++ b/src/interceptor/interceptable-http.ts
@@ -23,7 +23,6 @@ import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class InterceptableHttp extends Http {
-    // private interceptors: HttpInterceptor[];
     private firstInterceptor: HttpInterceptor;
 
     constructor(

--- a/src/interceptor/interceptable-http.ts
+++ b/src/interceptor/interceptable-http.ts
@@ -17,18 +17,19 @@
  limitations under the License.
  */
 import { HttpInterceptor } from './http.interceptor';
-import { Injectable } from '@angular/core';
+import { forwardRef, Inject, Injectable } from '@angular/core';
 import { Http, ConnectionBackend, RequestOptions, RequestOptionsArgs, Request, Response, Headers } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
 @Injectable()
 export class InterceptableHttp extends Http {
+    // private interceptors: HttpInterceptor[];
     private firstInterceptor: HttpInterceptor;
 
     constructor(
         backend: ConnectionBackend,
         defaultOptions: RequestOptions,
-        interceptors: HttpInterceptor[]
+        @Inject(forwardRef(() => HttpInterceptor)) interceptors: HttpInterceptor[]
     ) {
         super(backend, defaultOptions);
 


### PR DESCRIPTION
See jhipster/generator-jhipster#4794 last Angular task.

Here is my solution about de **Interceptable** warning.
I'm searching about the **AlertService** warning. It's related to the `boolean` in the AlertService constructor, I'm close to find it. 

**So, no need to be merged for the moment.**