### PR TITLE
Ensure that not a localized DatePipe is used, but always the 'en',

### DIFF
--- a/src/service/date-util.service.ts
+++ b/src/service/date-util.service.ts
@@ -27,7 +27,11 @@ export class JhiDateUtils {
 
     private pattern = 'yyyy-MM-dd';
 
-    constructor(private datePipe: DatePipe) {}
+    private datePipe: DatePipe;
+
+    constructor() {
+        this.datePipe = new DatePipe('en');
+    }
 
     /**
      * Method to convert the date time from server into JS date object


### PR DESCRIPTION
so the LocalDate is always formatted correctly, not local specific way. For unclear reasons, DatePipe thinks, that with the Hungarian locale, the date is needs to be formatted as _2017.-07-16_ - notice the dot after the year! This is not handled correctly on the server side, where it expects the LocalDate to be 2017-07-16