### PR TITLE
Add ability to edit seconds of timestamp

### DIFF
--- a/src/service/date-util.service.ts
+++ b/src/service/date-util.service.ts
@@ -80,6 +80,6 @@ export class JhiDateUtils {
             return null;
         }
         const dateParts = date.split(/\D+/);
-        return new Date(dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4]);
+        return new Date(dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4], dateParts[5]);
     }
 }

--- a/tests/service/date-util.service.spec.ts
+++ b/tests/service/date-util.service.spec.ts
@@ -76,7 +76,7 @@ describe('Date Utils service test', () => {
         it('should toDate convert datetime-local to date', inject([JhiDateUtils], (service: JhiDateUtils) => {
             const date = '2016-05-10T23:20:50.52';
             const dateValue = service.toDate(date);
-            expect(dateValue).toEqual(new Date('2016-05-10 23:20'));
+            expect(dateValue).toEqual(new Date('2016-05-10 23:20:52'));
             expect(dateValue instanceof Date).toBe(true);
         }));
 

--- a/tests/service/date-util.service.spec.ts
+++ b/tests/service/date-util.service.spec.ts
@@ -76,7 +76,7 @@ describe('Date Utils service test', () => {
         it('should toDate convert datetime-local to date', inject([JhiDateUtils], (service: JhiDateUtils) => {
             const date = '2016-05-10T23:20:50.52';
             const dateValue = service.toDate(date);
-            expect(dateValue).toEqual(new Date('2016-05-10 23:20:52'));
+            expect(dateValue).toEqual(new Date('2016-05-10 23:20:50'));
             expect(dateValue instanceof Date).toBe(true);
         }));
 


### PR DESCRIPTION
Today there is no ability to edit the seconds part of a timestamp.
I had a PR to support it by the UI, but this util have to be aware to this part.

Please approve this PR ONLY AFTER this PR will be approved: https://github.com/jhipster/generator-jhipster/pull/6181