### PR TITLE
fix JhiDateUtils.toDate when missing seconds

### DIFF
--- a/src/service/date-util.service.ts
+++ b/src/service/date-util.service.ts
@@ -80,6 +80,12 @@ export class JhiDateUtils {
             return null;
         }
         const dateParts = date.split(/\D+/);
-        return new Date(dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4], dateParts[5]);
+        if (dateParts.length === 7) {
+            return new Date(dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4], dateParts[5], dateParts[6]);
+        }
+        if (dateParts.length === 6) {
+            return new Date(dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4], dateParts[5]);
+        }
+        return new Date(dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4]);
     }
 }

--- a/tests/service/date-util.service.spec.ts
+++ b/tests/service/date-util.service.spec.ts
@@ -74,9 +74,9 @@ describe('Date Utils service test', () => {
         }));
 
         it('should toDate convert datetime-local to date', inject([JhiDateUtils], (service: JhiDateUtils) => {
-            const date = '2016-05-10T23:20:50.52';
+            const date = '2016-05-10T23:20:50.567';
             const dateValue = service.toDate(date);
-            expect(dateValue).toEqual(new Date('2016-05-10 23:20:50'));
+            expect(dateValue).toEqual(new Date('2016-05-10 23:20:50.567'));
             expect(dateValue instanceof Date).toBe(true);
         }));
 


### PR DESCRIPTION
now you can pass all of these:

```
"2017-12-31T01:30" <-- this PR to fix this case when we use ZonedTimeDate or Instant
"2017-12-31T01:30:15"  
"2017-12-31T01:30:15.369" <-- also allows milliseconds
```