### PR TITLE
Fix error: Object doesn't support property or method 'forEach'

### DIFF
--- a/src/directive/sort.directive.ts
+++ b/src/directive/sort.directive.ts
@@ -61,6 +61,7 @@ export class JhiSortDirective {
 
     private resetClasses() {
         const allThIcons = this.element.querySelectorAll(this.sortIconSelector);
+        // Use normal loop instead of forEach because IE does not support forEach on NodeList.
         for (let i = 0; i < allThIcons.length; i++) {
             allThIcons[i].classList.remove(this.sortAscIcon);
             allThIcons[i].classList.remove(this.sortDescIcon);

--- a/src/directive/sort.directive.ts
+++ b/src/directive/sort.directive.ts
@@ -61,7 +61,7 @@ export class JhiSortDirective {
 
     private resetClasses() {
         const allThIcons = this.element.querySelectorAll(this.sortIconSelector);
-        for (var i = 0; i < allThIcons.length; i++) {
+        for (let i = 0; i < allThIcons.length; i++) {
             allThIcons[i].classList.remove(this.sortAscIcon);
             allThIcons[i].classList.remove(this.sortDescIcon);
             allThIcons[i].classList.add(this.sortIcon);


### PR DESCRIPTION
On IE 11+ when you click icon "sort", this error happen: "Object doesn't support property or method 'forEach'".