### PR TITLE
Apply CSS class in JhiSortByDirective on component load

### DIFF
--- a/src/directive/sort-by.directive.ts
+++ b/src/directive/sort-by.directive.ts
@@ -16,14 +16,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { Directive, Host, HostListener, Input, ElementRef, Renderer } from '@angular/core';
+import { Directive, Host, HostListener, Input, ElementRef, Renderer, AfterViewInit } from '@angular/core';
 import { JhiSortDirective } from './sort.directive';
 import { JhiConfigService } from '../config.service';
 
 @Directive({
     selector: '[jhiSortBy]'
 })
-export class JhiSortByDirective {
+export class JhiSortByDirective implements AfterViewInit {
+
     @Input() jhiSortBy: string;
 
     sortAscIcon = 'fa-sort-asc';
@@ -36,6 +37,12 @@ export class JhiSortByDirective {
         const config = configService.getConfig();
         this.sortAscIcon = config.sortAscIcon;
         this.sortDescIcon = config.sortDescIcon;
+    }
+
+    ngAfterViewInit(): void {
+        if (this.jhiSort.predicate && this.jhiSort.predicate !== '_score' && this.jhiSort.predicate === this.jhiSortBy) {
+            this.applyClass();
+        }
     }
 
     @HostListener('click') onClick() {


### PR DESCRIPTION
* **Overview of the request**

Show visual indicator on page load by which column a table is sort

* **Motivation for or Use Case** 

Once you reload a page or share a URL with some some that contains sort parameters (e.g. http://example.com/#/entity?page=1&size=15&search=&sort=name,asc) the page will load and apply the sorting to the table that lists the entities. But there is no visual indicator on the column's table head as it would if you would click on it for sorting.

* **Browsers and Operating System** 

Applies to all browsers and operating systems

* **Suggest a Fix** 

Merge this pull request to apply the CSS class on page load.