### PR TITLE
Remove HttpClientModule to avoid multiple instances

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@
  limitations under the License.
  */
 import { NgModule, ModuleWithProviders, Sanitizer } from '@angular/core';
-import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { TranslateModule, TranslateLoader, MissingTranslationHandler, TranslateService } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
@@ -61,7 +61,6 @@ export function missingTranslationHandler(configService: JhiConfigService) {
                 deps: [JhiConfigService]
             }
         }),
-        HttpClientModule,
         CommonModule
     ],
     declarations: [
@@ -76,7 +75,6 @@ export function missingTranslationHandler(configService: JhiConfigService) {
         ...JHI_COMPONENTS,
         JhiTranslateComponent,
         TranslateModule,
-        HttpClientModule,
         CommonModule
     ]
 })

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@angular/compiler-cli": "^5.0.0",
     "@angular/core": "^5.0.0",
     "@angular/forms": "^5.0.0",
+    "@angular/http": "^5.2.7",
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/platform-server": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,12 @@
   dependencies:
     tslib "^1.7.1"
 
+"@angular/http@^5.2.7":
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-5.2.7.tgz#a163f6958f12d2665419123861b0d613c1c82afb"
+  dependencies:
+    tslib "^1.7.1"
+
 "@angular/platform-browser-dynamic@^5.0.0":
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.1.3.tgz#ad37e4dbd5251e7ea256ad9323fe11c848d04050"


### PR DESCRIPTION
While working on https://github.com/jhipster/generator-jhipster/pull/7231
I saw that our app had one httpclient instance per module, which is not recommended.
In the lazy loaded module the interceptors weren't working.
I decided to simply remove the `HttpClientModule`, it will be imported in the `CoreModule` in the JHipster application.