### PR TITLE
fix sortIconSelector

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export class JhiModuleConfig {
     sortIcon ? = 'fa-sort';
     sortAscIcon ? = 'fa-sort-up';
     sortDescIcon ? = 'fa-sort-down';
-    sortIconSelector ? = 'span.fa';
+    sortIconSelector ? = 'fa-icon';
     i18nEnabled ? = false;
     defaultI18nLang ? = 'en';
     noi18nMessage ? = 'translation-not-found';

--- a/src/directive/sort-by.directive.ts
+++ b/src/directive/sort-by.directive.ts
@@ -27,6 +27,7 @@ export class JhiSortByDirective implements AfterViewInit {
 
     @Input() jhiSortBy: string;
 
+    sortIcon = 'fa-sort';
     sortAscIcon = 'fa-sort-up';
     sortDescIcon = 'fa-sort-down';
 
@@ -58,6 +59,7 @@ export class JhiSortByDirective implements AfterViewInit {
         if (!this.jhiSort.ascending) {
             add = this.sortDescIcon;
         }
+        this.renderer.setElementClass(childSpan, this.sortIcon, false);
         this.renderer.setElementClass(childSpan, add, true);
     };
 }

--- a/src/directive/sort.directive.ts
+++ b/src/directive/sort.directive.ts
@@ -30,7 +30,7 @@ export class JhiSortDirective {
     sortIcon = 'fa-sort';
     sortAscIcon = 'fa-sort-up';
     sortDescIcon = 'fa-sort-down';
-    sortIconSelector = 'span.fa';
+    sortIconSelector = 'fa-icon';
 
     @Output() predicateChange: EventEmitter<any> = new EventEmitter();
     @Output() ascendingChange: EventEmitter<any> = new EventEmitter();

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -25,7 +25,7 @@ describe('ModuleConfig Test', () => {
     expect(config.sortIcon).toBe('fa-sort');
     expect(config.sortAscIcon).toBe('fa-sort-up');
     expect(config.sortDescIcon).toBe('fa-sort-down');
-    expect(config.sortIconSelector).toBe('span.fa');
+    expect(config.sortIconSelector).toBe('fa-icon');
     expect(config.i18nEnabled).toBe(false);
     expect(config.alertAsToast).toBe(false);
     expect(config.defaultI18nLang).toBe('en');


### PR DESCRIPTION
Set sortIconSelector to 'fa-icon' (I'm trying to fix ordering icon in user management)

So now we have:
`<fa-icon class="ng-fa-icon fa-sort-up" ng-reflect-icon-prop="sort">...</fa-icon>`
or
`<fa-icon class="ng-fa-icon fa-sort-down" ng-reflect-icon-prop="sort">...</fa-icon>`

But it seems that the underlying svg is not "re-rendered" to display the correct icon.
I don't really know how it works, do you have an idea ?