### PR TITLE
Move i18n bundles to content directory that's cached by server

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ export * from './src/config.service';
 export * from './src/config';
 
 export function translatePartialLoader(http: HttpClient) {
-    return new TranslateHttpLoader(http, 'i18n/', `.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
+    return new TranslateHttpLoader(http, 'content/i18n/', `.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
 }
 
 export function missingTranslationHandler(configService: JhiConfigService) {


### PR DESCRIPTION
Move i18n bundles to content directory that's cached by server as static asset