### PR TITLE
Added callbacks to setFileData method

### DIFF
--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -124,16 +124,26 @@ export class JhiDataUtils {
         return size.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') + ' bytes';
     }
 
-    setFileData(event, entity, field: string, isImage: boolean) {
+    setFileData(event, entity, field: string, isImage: boolean, onSuccess?: () => void, onError?: () => void) {
         if (event && event.target.files && event.target.files[0]) {
             const file = event.target.files[0];
             if (isImage && !/^image\//.test(file.type)) {
+                if (onError) {
+                    onError();
+                }
                 return;
             }
             this.toBase64(file, (base64Data) => {
                 entity[field] = base64Data;
                 entity[`${field}ContentType`] = file.type;
+                if (onSuccess) {
+                    onSuccess();
+                }
             });
+        } else {
+            if (onError) {
+                onError();
+            }
         }
     }
 


### PR DESCRIPTION
I used the setFileData method to read some image. When using the image after calling setFileData, sometimes the image was set and sometimes not. It would be nice to have a callback, so actions can be taken immediately after the image has been loaded. This is what I have done in this pull request.