### PR TITLE
Return promise from dataUtilService.setFileData() to let caller have better control

### DIFF
--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -123,6 +123,16 @@ export class JhiDataUtils {
         return size.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') + ' bytes';
     }
 
+    /**
+     * Sets the base 64 data & file type of the 1st file on the event (event.target.files[0]) in the passed entity object
+     *
+     * @param event the object containing the file (at event.target.files[0])
+     * @param entity the object to set the file's 'base 64 data' and 'file type' on
+     * @param {string} field the field name to set the file's 'base 64 data' on
+     * @param {boolean} isImage boolean representing if the file represented by the event is an image
+     * @param {Function} onSuccess optional callback to be executed upon successful setting of data
+     * @param {Function} onError optional callback to be executed upon unsuccessful setting of data
+     */
     setFileData(event, entity, field: string, isImage: boolean, onSuccess?: Function, onError?: Function) {
         if (event && event.target.files && event.target.files[0]) {
             const file = event.target.files[0];

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -26,7 +26,8 @@ import { ElementRef, Injectable } from '@angular/core';
 })
 export class JhiDataUtils {
 
-    constructor() {}
+    constructor() {
+    }
 
     /**
      * Method to abbreviate the text given
@@ -122,15 +123,21 @@ export class JhiDataUtils {
         return size.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') + ' bytes';
     }
 
-    setFileData(event, entity, field: string, isImage: boolean) {
+    setFileData(event, entity, field: string, isImage: boolean, cb?: Function) {
         if (event && event.target.files && event.target.files[0]) {
             const file = event.target.files[0];
             if (isImage && !/^image\//.test(file.type)) {
+                if (cb) {
+                    cb();
+                }
                 return;
             }
             this.toBase64(file, (base64Data) => {
                 entity[field] = base64Data;
                 entity[`${field}ContentType`] = file.type;
+                if (cb) {
+                    cb();
+                }
             });
         }
     }

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -68,7 +68,7 @@ export class JhiDataUtils {
             const fileURL = `data:${contentType};base64,${data}`;
             const win = window.open();
             win.document.write(
-                '<iframe src="' + fileURL + '" frameborder="0" style="border:0; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%;" allowfullscreen></iframe>');
+                '<iframe src="' + fileURL + '" frameborder="0" style="border:0; top:0; left:0; bottom:0; right:0; width:100%; height:100%;" allowfullscreen></iframe>');
         }
     }
 

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -77,11 +77,11 @@ export class JhiDataUtils {
      */
     toBase64(file: File, cb: Function) {
         const fileReader: FileReader = new FileReader();
-        fileReader.readAsDataURL(file);
         fileReader.onload = function(e: any) {
             const base64Data = e.target.result.substr(e.target.result.indexOf('base64,') + 'base64,'.length);
             cb(base64Data);
         };
+        fileReader.readAsDataURL(file);
     }
 
     /**

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -130,15 +130,15 @@ export class JhiDataUtils {
      * @param entity the object to set the file's 'base 64 data' and 'file type' on
      * @param {string} field the field name to set the file's 'base 64 data' on
      * @param {boolean} isImage boolean representing if the file represented by the event is an image
-     * @param {Function} onSuccess optional callback to be executed upon successful setting of data
-     * @param {Function} onError optional callback to be executed upon unsuccessful setting of data
+     * @param {Function} onSuccess optional callback to be executed upon successful setting of data (modified entity object is passed to this callback)
+     * @param {Function} onError optional callback to be executed upon unsuccessful setting of data (error message is passed to this callback)
      */
     setFileData(event, entity, field: string, isImage: boolean, onSuccess?: Function, onError?: Function) {
         if (event && event.target.files && event.target.files[0]) {
             const file = event.target.files[0];
             if (isImage && !/^image\//.test(file.type)) {
                 if (onError) {
-                    onError();
+                    onError(`File was expected to be an image but was found to be ${file.type}`);
                 }
                 return;
             }

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -125,31 +125,29 @@ export class JhiDataUtils {
 
     /**
      * Sets the base 64 data & file type of the 1st file on the event (event.target.files[0]) in the passed entity object
+     * and returns a promise.
      *
      * @param event the object containing the file (at event.target.files[0])
      * @param entity the object to set the file's 'base 64 data' and 'file type' on
      * @param field the field name to set the file's 'base 64 data' on
      * @param isImage boolean representing if the file represented by the event is an image
-     * @param onSuccess optional callback to be executed upon successful setting of data (modified entity object is passed to this callback)
-     * @param onError optional callback to be executed upon unsuccessful setting of data (error message is passed to this callback)
+     * @returns a promise that resolves to the modified entity if operation is successful, otherwise rejects with an error message
      */
-    setFileData(event, entity, field: string, isImage: boolean, onSuccess?: Function, onError?: Function) {
-        if (event && event.target.files && event.target.files[0]) {
-            const file = event.target.files[0];
-            if (isImage && !/^image\//.test(file.type)) {
-                if (onError) {
-                    onError(`File was expected to be an image but was found to be ${file.type}`);
+    setFileData(event, entity, field: string, isImage: boolean): Promise<any> {
+        return new Promise((resolve, reject) => {
+            if (event && event.target.files && event.target.files[0]) {
+                const file = event.target.files[0];
+                if (isImage && !/^image\//.test(file.type)) {
+                    reject(`File was expected to be an image but was found to be ${file.type}`);
+                } else {
+                    this.toBase64(file, (base64Data) => {
+                        entity[field] = base64Data;
+                        entity[`${field}ContentType`] = file.type;
+                        resolve(entity);
+                    });
                 }
-                return;
             }
-            this.toBase64(file, (base64Data) => {
-                entity[field] = base64Data;
-                entity[`${field}ContentType`] = file.type;
-                if (onSuccess) {
-                    onSuccess(entity);
-                }
-            });
-        }
+        });
     }
 
     /**

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -135,7 +135,7 @@ export class JhiDataUtils {
      */
     setFileData(event, entity, field: string, isImage: boolean): Promise<any> {
         return new Promise((resolve, reject) => {
-            if (event && event.target.files && event.target.files[0]) {
+            if (event && event.target && event.target.files && event.target.files[0]) {
                 const file = event.target.files[0];
                 if (isImage && !/^image\//.test(file.type)) {
                     reject(`File was expected to be an image but was found to be ${file.type}`);
@@ -146,6 +146,8 @@ export class JhiDataUtils {
                         resolve(entity);
                     });
                 }
+            } else {
+                reject(`Base64 data was not set as file could not be extracted from passed parameter: ${event}`);
             }
         });
     }

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -123,20 +123,20 @@ export class JhiDataUtils {
         return size.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') + ' bytes';
     }
 
-    setFileData(event, entity, field: string, isImage: boolean, cb?: Function) {
+    setFileData(event, entity, field: string, isImage: boolean, onSuccess?: Function, onError?: Function) {
         if (event && event.target.files && event.target.files[0]) {
             const file = event.target.files[0];
             if (isImage && !/^image\//.test(file.type)) {
-                if (cb) {
-                    cb(entity);
+                if (onError) {
+                    onError();
                 }
                 return;
             }
             this.toBase64(file, (base64Data) => {
                 entity[field] = base64Data;
                 entity[`${field}ContentType`] = file.type;
-                if (cb) {
-                    cb(entity);
+                if (onSuccess) {
+                    onSuccess(entity);
                 }
             });
         }

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -128,10 +128,10 @@ export class JhiDataUtils {
      *
      * @param event the object containing the file (at event.target.files[0])
      * @param entity the object to set the file's 'base 64 data' and 'file type' on
-     * @param {string} field the field name to set the file's 'base 64 data' on
-     * @param {boolean} isImage boolean representing if the file represented by the event is an image
-     * @param {Function} onSuccess optional callback to be executed upon successful setting of data (modified entity object is passed to this callback)
-     * @param {Function} onError optional callback to be executed upon unsuccessful setting of data (error message is passed to this callback)
+     * @param field the field name to set the file's 'base 64 data' on
+     * @param isImage boolean representing if the file represented by the event is an image
+     * @param onSuccess optional callback to be executed upon successful setting of data (modified entity object is passed to this callback)
+     * @param onError optional callback to be executed upon unsuccessful setting of data (error message is passed to this callback)
      */
     setFileData(event, entity, field: string, isImage: boolean, onSuccess?: Function, onError?: Function) {
         if (event && event.target.files && event.target.files[0]) {

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -128,7 +128,7 @@ export class JhiDataUtils {
             const file = event.target.files[0];
             if (isImage && !/^image\//.test(file.type)) {
                 if (cb) {
-                    cb();
+                    cb(entity);
                 }
                 return;
             }
@@ -136,7 +136,7 @@ export class JhiDataUtils {
                 entity[field] = base64Data;
                 entity[`${field}ContentType`] = file.type;
                 if (cb) {
-                    cb();
+                    cb(entity);
                 }
             });
         }

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -46,9 +46,9 @@ describe('Data Utils Service Test', () => {
     }));
 
     it('should download the csv file', inject([JhiDataUtils], (service: JhiDataUtils) => {
-            const tempLink = document.createElement('a');
-            jest.spyOn(tempLink, 'click');
-            jest.spyOn(document, 'createElement').mockReturnValue(tempLink);
+        const tempLink = document.createElement('a');
+        jest.spyOn(tempLink, 'click');
+        jest.spyOn(document, 'createElement').mockReturnValue(tempLink);
         // call downloadFile function
         // csv content:
         // ID,Name
@@ -59,19 +59,19 @@ describe('Data Utils Service Test', () => {
         service.downloadFile(contentType, data, fileName);
         expect(document.createElement).toHaveBeenCalledTimes(1);
         expect(document.createElement).toHaveBeenCalledWith('a');
-            expect(tempLink.target).toBe('_blank');
-            expect(tempLink.download).toBe('test-download-file.csv');
-            expect(tempLink.click).toHaveBeenCalledTimes(1);
-            expect(tempLink.click).toHaveBeenCalledWith();
+        expect(tempLink.target).toBe('_blank');
+        expect(tempLink.download).toBe('test-download-file.csv');
+        expect(tempLink.click).toHaveBeenCalledTimes(1);
+        expect(tempLink.click).toHaveBeenCalledWith();
     }));
 
     it('should execute the toBase64()', inject([JhiDataUtils], (service: JhiDataUtils) => {
 
-        spyOn(service, 'toBase64');
+        jest.spyOn(service, 'toBase64');
 
         const eventSake = {
             target: {
-                files: [{}]
+                files: [new Blob()]
             }
         };
 
@@ -84,7 +84,7 @@ describe('Data Utils Service Test', () => {
 
     it('should skip the toBase64() when image is passed', inject([JhiDataUtils], (service: JhiDataUtils) => {
 
-        spyOn(service, 'toBase64');
+        jest.spyOn(service, 'toBase64');
 
         const eventSake = {
             target: {
@@ -114,7 +114,8 @@ describe('Data Utils Service Test', () => {
             service.setFileData(eventSake, entity, field, false, callBack);
 
             setTimeout(() => {
-                expect(callBack).toHaveBeenCalled();
+                const modifiedEntity = { document: 'ZmlsZSBjb250ZW50', documentContentType: '' };
+                expect(callBack).toHaveBeenCalledWith(modifiedEntity);
                 expect(entity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' });
             }, 500);
         })();

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -20,107 +20,104 @@ import { TestBed, inject } from '@angular/core/testing';
 
 import { JhiDataUtils } from '../../src/service/data-util.service';
 
-describe('Data Utils service test', () => {
-
-    describe('Data Utils Service Test', () => {
-        beforeEach(() => {
-            TestBed.configureTestingModule({
-                providers: [
-                    JhiDataUtils
-                ]
-            });
+describe('Data Utils Service Test', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                JhiDataUtils
+            ]
         });
+    });
 
-        it('should not abbreviate the text when below cutoff', inject([JhiDataUtils], (service: JhiDataUtils) => {
-            expect(service.abbreviate('Hello Jhipster')).toBe('Hello Jhipster');
-        }));
+    it('should not abbreviate the text when below cutoff', inject([JhiDataUtils], (service: JhiDataUtils) => {
+        expect(service.abbreviate('Hello Jhipster')).toBe('Hello Jhipster');
+    }));
 
-        it('should abbreviate the text and append ...', inject([JhiDataUtils], (service: JhiDataUtils) => {
-            expect(service.abbreviate('Hello Jhipster lets test the data utils function')).toBe('Hello Jhipster ...s function');
-        }));
+    it('should abbreviate the text and append ...', inject([JhiDataUtils], (service: JhiDataUtils) => {
+        expect(service.abbreviate('Hello Jhipster lets test the data utils function')).toBe('Hello Jhipster ...s function');
+    }));
 
-        it('should abbreviate the text and append +++', inject([JhiDataUtils], (service: JhiDataUtils) => {
-            expect(service.abbreviate('Hello Jhipster lets test the data utils function', '+++')).toBe('Hello Jhipster +++s function');
-        }));
+    it('should abbreviate the text and append +++', inject([JhiDataUtils], (service: JhiDataUtils) => {
+        expect(service.abbreviate('Hello Jhipster lets test the data utils function', '+++')).toBe('Hello Jhipster +++s function');
+    }));
 
-        it('should return the bytesize of the text', inject([JhiDataUtils], (service: JhiDataUtils) => {
-            expect(service.byteSize('Hello Jhipster')).toBe(`10.5 bytes`);
-        }));
+    it('should return the bytesize of the text', inject([JhiDataUtils], (service: JhiDataUtils) => {
+        expect(service.byteSize('Hello Jhipster')).toBe(`10.5 bytes`);
+    }));
 
-        it('should download the csv file', inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should download the csv file', inject([JhiDataUtils], (service: JhiDataUtils) => {
             const tempLink = document.createElement('a');
             jest.spyOn(tempLink, 'click');
             jest.spyOn(document, 'createElement').mockReturnValue(tempLink);
-            // call downloadFile function
-            // csv content:
-            // ID,Name
-            // 1,Toto
-            const contentType = 'text/csv';
-            const data = 'SUQsTmFtZQ0KMSxUb3Rv';
-            const fileName = 'test-download-file.csv';
-            service.downloadFile(contentType, data, fileName);
-            expect(document.createElement).toHaveBeenCalledTimes(1);
-            expect(document.createElement).toHaveBeenCalledWith('a');
+        // call downloadFile function
+        // csv content:
+        // ID,Name
+        // 1,Toto
+        const contentType = 'text/csv';
+        const data = 'SUQsTmFtZQ0KMSxUb3Rv';
+        const fileName = 'test-download-file.csv';
+        service.downloadFile(contentType, data, fileName);
+        expect(document.createElement).toHaveBeenCalledTimes(1);
+        expect(document.createElement).toHaveBeenCalledWith('a');
             expect(tempLink.target).toBe('_blank');
             expect(tempLink.download).toBe('test-download-file.csv');
             expect(tempLink.click).toHaveBeenCalledTimes(1);
             expect(tempLink.click).toHaveBeenCalledWith();
-        }));
+    }));
 
-        it('should execute the toBase64()', inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should execute the toBase64()', inject([JhiDataUtils], (service: JhiDataUtils) => {
 
-            spyOn(service, 'toBase64');
+        spyOn(service, 'toBase64');
 
+        const eventSake = {
+            target: {
+                files: [{}]
+            }
+        };
+
+        service.setFileData(eventSake, null, null, false);
+
+        setTimeout(() => {
+            expect(service.toBase64).toHaveBeenCalled();
+        }, 500);
+    }));
+
+    it('should skip the toBase64() when image is passed', inject([JhiDataUtils], (service: JhiDataUtils) => {
+
+        spyOn(service, 'toBase64');
+
+        const eventSake = {
+            target: {
+                files: [{}]
+            }
+        };
+
+        service.setFileData(eventSake, null, null, true);
+
+        expect(service.toBase64).toHaveBeenCalledTimes(0);
+    }));
+
+    it('should execute the callback in toBase64()', function(done) {
+        inject([JhiDataUtils], (service: JhiDataUtils) => {
+            const callBack: Spy = jasmine.createSpy();
+            callBack.and.callFake(() => done());
+
+            const file = new File(['file content'], 'test-file.txt');
             const eventSake = {
                 target: {
-                    files: [{}]
+                    files: [file]
                 }
             };
 
-            service.setFileData(eventSake, null, null, false);
+            const entity = {};
+            const field = 'document';
+            service.setFileData(eventSake, entity, field, false, callBack);
 
             setTimeout(() => {
-                expect(service.toBase64).toHaveBeenCalled();
+                expect(callBack).toHaveBeenCalled();
+                expect(entity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' });
             }, 500);
-        }));
-
-        it('should skip the toBase64() when image is passed', inject([JhiDataUtils], (service: JhiDataUtils) => {
-
-            spyOn(service, 'toBase64');
-
-            const eventSake = {
-                target: {
-                    files: [{}]
-                }
-            };
-
-            service.setFileData(eventSake, null, null, true);
-
-            expect(service.toBase64).toHaveBeenCalledTimes(0);
-        }));
-
-        it('should execute the callback in toBase64()', function(done) {
-            inject([JhiDataUtils], (service: JhiDataUtils) => {
-                const callBack: Spy = jasmine.createSpy();
-                callBack.and.callFake(() => done());
-
-                const file = new File(['file content'], 'test-file.txt');
-                const eventSake = {
-                    target: {
-                        files: [file]
-                    }
-                };
-
-                const entity = {};
-                const field = 'document';
-                service.setFileData(eventSake, entity, field, false, callBack);
-
-                setTimeout(() => {
-                    expect(callBack).toHaveBeenCalled();
-                    expect(entity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' });
-                }, 500);
-            })();
-        });
-
+        })();
     });
+
 });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -66,5 +66,38 @@ describe('Data Utils service test', () => {
             expect(tempLink.click).toHaveBeenCalledTimes(1);
             expect(tempLink.click).toHaveBeenCalledWith();
         }));
+
+        it('should execute the toBase64()', inject([JhiDataUtils], (service: JhiDataUtils) => {
+
+            spyOn(service, 'toBase64');
+
+            const eventSake = {
+                target: {
+                    files: [{}]
+                }
+            };
+
+            service.setFileData(eventSake, null, null, false);
+
+            setTimeout(() => {
+                expect(service.toBase64).toHaveBeenCalled();
+            }, 500);
+        }));
+
+        it('should skip the toBase64() when image is passed', inject([JhiDataUtils], (service: JhiDataUtils) => {
+
+            spyOn(service, 'toBase64');
+
+            const eventSake = {
+                target: {
+                    files: [{}]
+                }
+            };
+
+            service.setFileData(eventSake, null, null, true);
+
+            expect(service.toBase64).toHaveBeenCalledTimes(0);
+        }));
+
     });
 });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -94,4 +94,14 @@ describe('Data Utils Service Test', () => {
 
     })()));
 
+    it('should return a promise that rejects with an error message when passed event does not contain a file', async(() => inject([JhiDataUtils], (service: JhiDataUtils) => {
+
+        service.setFileData(null, null, null, false)
+               .then(
+                   () => fail('Should not resolve'),
+                   (error) => expect(error).toMatch(/^Base64 data was not set as file could not be extracted from passed parameter: /)
+               );
+
+    })()));
+
 });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -84,8 +84,11 @@ describe('Data Utils Service Test', () => {
     it('should not call toBase64() when image is passed and file type is not image', (done) => inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         jest.spyOn(service, 'toBase64');
-        const mockCallback = jest.fn(() => {
-            expect(mockCallback.mock.calls.length).toBe(1);
+        const mockSuccessCallback = jest.fn(() => {
+        });
+        const mockErrorCallback = jest.fn(() => {
+            expect(mockSuccessCallback.mock.calls.length).toBe(0);
+            expect(mockErrorCallback.mock.calls.length).toBe(1);
             expect(service.toBase64).toHaveBeenCalledTimes(0);
             done();
         });
@@ -96,16 +99,16 @@ describe('Data Utils Service Test', () => {
             }
         };
 
-        service.setFileData(eventSake, null, null, true, mockCallback);
+        service.setFileData(eventSake, null, null, true, mockSuccessCallback, mockErrorCallback);
 
     })());
 
     it('should execute the callback in toBase64()', (done) => inject([JhiDataUtils], (service: JhiDataUtils) => {
         const entity = {};
-        const mockCallback = jest.fn((arg) => {
+        const mockSuccessCallback = jest.fn((arg) => {
             const modifiedEntity = { document: 'ZmlsZSBjb250ZW50', documentContentType: '' };
-            expect(mockCallback.mock.calls.length).toBe(1);
-            expect(mockCallback.mock.calls[0][0]).toEqual(modifiedEntity);
+            expect(mockSuccessCallback.mock.calls.length).toBe(1);
+            expect(mockSuccessCallback.mock.calls[0][0]).toEqual(modifiedEntity);
             expect(arg).toEqual(modifiedEntity);
             expect(entity).toEqual(modifiedEntity);
             done();
@@ -117,7 +120,7 @@ describe('Data Utils Service Test', () => {
             }
         };
 
-        service.setFileData(eventSake, entity, 'document', false, mockCallback);
+        service.setFileData(eventSake, entity, 'document', false, mockSuccessCallback);
 
     })());
 

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -81,9 +81,14 @@ describe('Data Utils Service Test', () => {
         expect(service.toBase64).toHaveBeenCalled();
     })()));
 
-    it('should skip the toBase64() when image is passed', inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should not call toBase64() when image is passed and file type is not image', (done) => inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         jest.spyOn(service, 'toBase64');
+        const mockCallback = jest.fn(() => {
+            expect(mockCallback.mock.calls.length).toBe(1);
+            expect(service.toBase64).toHaveBeenCalledTimes(0);
+            done();
+        });
 
         const eventSake = {
             target: {
@@ -91,10 +96,9 @@ describe('Data Utils Service Test', () => {
             }
         };
 
-        service.setFileData(eventSake, null, null, true);
+        service.setFileData(eventSake, null, null, true, mockCallback);
 
-        expect(service.toBase64).toHaveBeenCalledTimes(0);
-    }));
+    })());
 
     it('should execute the callback in toBase64()', (done) => inject([JhiDataUtils], (service: JhiDataUtils) => {
         const entity = {};

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -65,7 +65,7 @@ describe('Data Utils Service Test', () => {
         expect(tempLink.click).toHaveBeenCalledWith();
     }));
 
-    it('should return a promise that rejects with an error message when image is passed but file type is not image', async(() => inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should return a promise that rejects with an error message when image is passed but file type is not image', async(inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         const eventSake = {
             target: {
@@ -79,9 +79,9 @@ describe('Data Utils Service Test', () => {
                    (error) => expect(error).toMatch(/^File was expected to be an image but was found to be /)
                );
 
-    })()));
+    })));
 
-    it('should return a promise that resolves to the modified entity', async(() => inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should return a promise that resolves to the modified entity', async(inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         const eventSake = {
             target: {
@@ -92,9 +92,9 @@ describe('Data Utils Service Test', () => {
         service.setFileData(eventSake, {}, 'document', false)
                .then((modifiedEntity) => expect(modifiedEntity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' }));
 
-    })()));
+    })));
 
-    it('should return a promise that rejects with an error message when passed event does not contain a file', async(() => inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should return a promise that rejects with an error message when passed event does not contain a file', async(inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         service.setFileData(null, null, null, false)
                .then(
@@ -102,6 +102,6 @@ describe('Data Utils Service Test', () => {
                    (error) => expect(error).toMatch(/^Base64 data was not set as file could not be extracted from passed parameter: /)
                );
 
-    })()));
+    })));
 
 });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { inject, TestBed } from '@angular/core/testing';
+import { async, inject, TestBed } from '@angular/core/testing';
 
 import { JhiDataUtils } from '../../src/service/data-util.service';
 
@@ -65,7 +65,7 @@ describe('Data Utils Service Test', () => {
         expect(tempLink.click).toHaveBeenCalledWith();
     }));
 
-    it('should return a promise that rejects with an error message when image is passed but file type is not image', inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should return a promise that rejects with an error message when image is passed but file type is not image', async(() => inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         const eventSake = {
             target: {
@@ -79,9 +79,9 @@ describe('Data Utils Service Test', () => {
                    (error) => expect(error).toMatch(/^File was expected to be an image but was found to be /)
                );
 
-    }));
+    })()));
 
-    it('should return a promise that resolves to the modified entity', inject([JhiDataUtils], (service: JhiDataUtils) => {
+    it('should return a promise that resolves to the modified entity', async(() => inject([JhiDataUtils], (service: JhiDataUtils) => {
 
         const eventSake = {
             target: {
@@ -92,6 +92,6 @@ describe('Data Utils Service Test', () => {
         service.setFileData(eventSake, {}, 'document', false)
                .then((modifiedEntity) => expect(modifiedEntity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' }));
 
-    }));
+    })()));
 
 });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -76,7 +76,7 @@ describe('Data Utils Service Test', () => {
         service.setFileData(eventSake, null, null, true)
                .then(
                    () => fail('Should not resolve'),
-                   error => expect(error).toMatch(/^File was expected to be an image but was found to be /)
+                   (error) => expect(error).toMatch(/^File was expected to be an image but was found to be /)
                );
 
     }));
@@ -90,7 +90,7 @@ describe('Data Utils Service Test', () => {
         };
 
         service.setFileData(eventSake, {}, 'document', false)
-               .then(modifiedEntity => expect(modifiedEntity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' }));
+               .then((modifiedEntity) => expect(modifiedEntity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' }));
 
     }));
 

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -99,5 +99,28 @@ describe('Data Utils service test', () => {
             expect(service.toBase64).toHaveBeenCalledTimes(0);
         }));
 
+        it('should execute the callback in toBase64()', function(done) {
+            inject([JhiDataUtils], (service: JhiDataUtils) => {
+                const callBack: Spy = jasmine.createSpy();
+                callBack.and.callFake(() => done());
+
+                const file = new File(['file content'], 'test-file.txt');
+                const eventSake = {
+                    target: {
+                        files: [file]
+                    }
+                };
+
+                const entity = {};
+                const field = 'document';
+                service.setFileData(eventSake, entity, field, false, callBack);
+
+                setTimeout(() => {
+                    expect(callBack).toHaveBeenCalled();
+                    expect(entity).toEqual({ document: 'ZmlsZSBjb250ZW50', documentContentType: '' });
+                }, 500);
+            })();
+        });
+
     });
 });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -102,9 +102,11 @@ describe('Data Utils Service Test', () => {
 
     it('should execute the callback in toBase64()', (done) => inject([JhiDataUtils], (service: JhiDataUtils) => {
         const entity = {};
-        const mockCallback = jest.fn(() => {
+        const mockCallback = jest.fn((arg) => {
             const modifiedEntity = { document: 'ZmlsZSBjb250ZW50', documentContentType: '' };
             expect(mockCallback.mock.calls.length).toBe(1);
+            expect(mockCallback.mock.calls[0][0]).toEqual(modifiedEntity);
+            expect(arg).toEqual(modifiedEntity);
             expect(entity).toEqual(modifiedEntity);
             done();
         });

--- a/tests/service/data-util.service.spec.ts
+++ b/tests/service/data-util.service.spec.ts
@@ -89,6 +89,7 @@ describe('Data Utils Service Test', () => {
         const mockErrorCallback = jest.fn(() => {
             expect(mockSuccessCallback.mock.calls.length).toBe(0);
             expect(mockErrorCallback.mock.calls.length).toBe(1);
+            expect(mockErrorCallback.mock.calls[0][0]).toMatch(/^File was expected to be an image but was found to be /);
             expect(service.toBase64).toHaveBeenCalledTimes(0);
             done();
         });


### PR DESCRIPTION
This will allow caller to pass in a callback method that will be executed after setting of the file data on the entity object is complete.

More details here: [#8772](https://github.com/jhipster/generator-jhipster/issues/8772) 