### PR TITLE
Listen to onLangChange event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6971,7 +6971,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -8562,7 +8562,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/src/language/jhi-translate.directive.ts
+++ b/src/language/jhi-translate.directive.ts
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { Input, Directive, ElementRef, OnChanges } from '@angular/core';
+import { Input, Directive, ElementRef, OnChanges, OnInit } from '@angular/core';
 import { JhiConfigService } from '../config.service';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -26,7 +26,7 @@ import { TranslateService } from '@ngx-translate/core';
 @Directive({
     selector: '[jhiTranslate]'
 })
-export class JhiTranslateDirective implements OnChanges {
+export class JhiTranslateDirective implements OnChanges, OnInit {
     @Input() jhiTranslate: string;
     @Input() translateValues: any;
 
@@ -36,11 +36,25 @@ export class JhiTranslateDirective implements OnChanges {
         private translateService: TranslateService
     ) {}
 
+    ngOnInit() {
+        const enabled = this.configService.getConfig().i18nEnabled;
+        if (enabled) {
+            this.translateService.onLangChange.subscribe(() => {
+                this.getTranslation();
+            })
+        }
+    }
+
     ngOnChanges() {
         const enabled = this.configService.getConfig().i18nEnabled;
 
         if (enabled) {
-            this.translateService
+            this.getTranslation();
+        }
+    }
+
+    private getTranslation() {
+        this.translateService
                 .get(this.jhiTranslate, this.translateValues)
                 .subscribe(
                     (value) => {
@@ -52,6 +66,5 @@ export class JhiTranslateDirective implements OnChanges {
                         }[${this.jhiTranslate}]`;
                     }
                 );
-        }
     }
 }


### PR DESCRIPTION
We now listen to `onLangChange` event to refresh translation when the language change.

Fix https://github.com/jhipster/generator-jhipster/issues/9121