### PR TITLE
fix deprecated forRoot of NgbModule

### DIFF
--- a/src/ng-jhipster.module.ts
+++ b/src/ng-jhipster.module.ts
@@ -58,7 +58,7 @@ export function missingTranslationHandler(configService: JhiConfigService) {
             }
         }),
         CommonModule,
-        NgbModule.forRoot(),
+        NgbModule,
         FormsModule
     ],
     declarations: [...JHI_PIPES, ...JHI_DIRECTIVES, ...JHI_COMPONENTS, JhiTranslateDirective],


### PR DESCRIPTION
According to ng-bootstrap the forRoot method of all modules was been deprecated in version 3.0.0 and removed in version 5.0.0-rc.0:

https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CHANGELOG.md#500-rc0-2019-06-24