### PR TITLE
Revert "remove translateModule.forRoot()"

### DIFF
--- a/src/ng-jhipster.module.ts
+++ b/src/ng-jhipster.module.ts
@@ -45,6 +45,19 @@ export function missingTranslationHandler(configService: JhiConfigService) {
 @NgModule({
     imports: [
         CommonModule,
+        TranslateModule.forRoot({
+            loader: {
+                provide: TranslateLoader,
+                useFactory: translatePartialLoader,
+                deps: [HttpClient]
+            },
+            missingTranslationHandler: {
+                provide: MissingTranslationHandler,
+                useFactory: missingTranslationHandler,
+                deps: [JhiConfigService]
+            }
+        }),
+        CommonModule,
         NgbModule,
         FormsModule
     ],


### PR DESCRIPTION
This reverts commit b9a990a676c3d3acda02414a4e7890000767bcc1.

cc @vishal423 @wmarques 
I'm reverting this PR https://github.com/jhipster/ng-jhipster/pull/99
And it will impact this PR https://github.com/jhipster/generator-jhipster/pull/10069

After this revert, I can do a release, so we can work on these items:
- https://github.com/jhipster/generator-jhipster/issues/9982 (which is important)
- https://github.com/jhipster/generator-jhipster/issues/10209