### PR TITLE
Make translate functionality optional and tree-shakable

### DIFF
--- a/src/language/jhi-translate.directive.ts
+++ b/src/language/jhi-translate.directive.ts
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { Input, Directive, ElementRef, OnChanges, OnInit } from '@angular/core';
+import { Input, Directive, ElementRef, OnChanges, OnInit, Optional } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { JhiConfigService } from '../config.service';
@@ -31,7 +31,7 @@ export class JhiTranslateDirective implements OnChanges, OnInit {
     @Input() jhiTranslate: string;
     @Input() translateValues: any;
 
-    constructor(private configService: JhiConfigService, private el: ElementRef, private translateService: TranslateService) {}
+    constructor(private configService: JhiConfigService, private el: ElementRef, @Optional() private translateService: TranslateService) {}
 
     ngOnInit() {
         const enabled = this.configService.getConfig().i18nEnabled;

--- a/src/ng-jhipster.module.ts
+++ b/src/ng-jhipster.module.ts
@@ -18,10 +18,9 @@
  */
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { ModuleWithProviders, NgModule, Sanitizer } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { MissingTranslationHandler, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { JhiThreadModalComponent } from './component/metrics/jhi-metrics-modal-threads.component';
 import { JhiModuleConfig } from './config';
@@ -29,10 +28,6 @@ import { JhiConfigService } from './config.service';
 import { JHI_COMPONENTS, JHI_DIRECTIVES, JHI_PIPES } from './jhi-components';
 import { JhiMissingTranslationHandler } from './language/jhi-missing-translation.config';
 import { JhiTranslateDirective } from './language/jhi-translate.directive';
-import { JhiLanguageService } from './language/language.service';
-import { JhiAlertService } from './service/alert.service';
-import { JhiPaginationUtil } from './service/pagination-util.service';
-import { JhiResolvePagingParams } from './service/resolve-paging-params.service';
 
 export function translatePartialLoader(http: HttpClient) {
     return new TranslateHttpLoader(http, 'i18n/', `.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
@@ -43,55 +38,16 @@ export function missingTranslationHandler(configService: JhiConfigService) {
 }
 
 @NgModule({
-    imports: [
-        CommonModule,
-        TranslateModule.forRoot({
-            loader: {
-                provide: TranslateLoader,
-                useFactory: translatePartialLoader,
-                deps: [HttpClient]
-            },
-            missingTranslationHandler: {
-                provide: MissingTranslationHandler,
-                useFactory: missingTranslationHandler,
-                deps: [JhiConfigService]
-            }
-        }),
-        CommonModule,
-        NgbModule,
-        FormsModule
-    ],
+    imports: [CommonModule, NgbModule, FormsModule],
     declarations: [...JHI_PIPES, ...JHI_DIRECTIVES, ...JHI_COMPONENTS, JhiTranslateDirective],
     entryComponents: [JhiThreadModalComponent],
-    exports: [...JHI_PIPES, ...JHI_DIRECTIVES, ...JHI_COMPONENTS, JhiTranslateDirective, TranslateModule, CommonModule]
+    exports: [...JHI_PIPES, ...JHI_DIRECTIVES, ...JHI_COMPONENTS, JhiTranslateDirective, CommonModule]
 })
 export class NgJhipsterModule {
     static forRoot(moduleConfig: JhiModuleConfig): ModuleWithProviders {
         return {
             ngModule: NgJhipsterModule,
-            providers: [
-                {
-                    provide: JhiLanguageService,
-                    useClass: JhiLanguageService,
-                    deps: [TranslateService, JhiConfigService]
-                },
-                {
-                    provide: JhiResolvePagingParams,
-                    useClass: JhiResolvePagingParams,
-                    deps: [JhiPaginationUtil]
-                },
-                {
-                    provide: JhiAlertService,
-                    useClass: JhiAlertService,
-                    deps: [Sanitizer, JhiConfigService, TranslateService]
-                },
-                { provide: JhiModuleConfig, useValue: moduleConfig },
-                {
-                    provide: JhiConfigService,
-                    useClass: JhiConfigService,
-                    deps: [JhiModuleConfig]
-                }
-            ]
+            providers: [{ provide: JhiModuleConfig, useValue: moduleConfig }]
         };
     }
     static forChild(moduleConfig: JhiModuleConfig): ModuleWithProviders {

--- a/src/ng-jhipster.module.ts
+++ b/src/ng-jhipster.module.ts
@@ -50,10 +50,4 @@ export class NgJhipsterModule {
             providers: [{ provide: JhiModuleConfig, useValue: moduleConfig }]
         };
     }
-    static forChild(moduleConfig: JhiModuleConfig): ModuleWithProviders {
-        return {
-            ngModule: NgJhipsterModule,
-            providers: [{ provide: JhiModuleConfig, useValue: moduleConfig }]
-        };
-    }
 }

--- a/src/service/alert.service.ts
+++ b/src/service/alert.service.ts
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { Injectable, Sanitizer, SecurityContext } from '@angular/core';
+import { Injectable, Sanitizer, SecurityContext, Optional } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 import { JhiConfigService } from '../config.service';
@@ -45,7 +45,11 @@ export class JhiAlertService {
     private toast: boolean;
     private i18nEnabled: boolean;
 
-    constructor(private sanitizer: Sanitizer, private configService: JhiConfigService, private translateService: TranslateService) {
+    constructor(
+        private sanitizer: Sanitizer,
+        private configService: JhiConfigService,
+        @Optional() private translateService: TranslateService
+    ) {
         const config = this.configService.getConfig();
         this.toast = config.alertAsToast;
         this.i18nEnabled = config.i18nEnabled;


### PR DESCRIPTION
This is improved version of the #99 which was merged and then reverted by #102 because this caused errors in app generated by `generator-jhipster` if i18n was disabled (`TranslateService` was not found in dependency injection).
If this change will be accepted and new version of `ng-jhipster` released then before new version can be used in `generator-jhipster`, the jhipster/generator-jhipster#10069 must be merged.

Starting from Angular 6 no more needed to include services in the module providers section.
Removing services from module providers section makes them tree-shakable (https://blog.angularindepth.com/tree-shakable-dependencies-in-angular-projects-5aaa7012b9e7).
If JHipster app is generated without i18n support then translation functionality is now excluded in this case.

Tested these `ng-jhipster` changes with jhipster/generator-jhipster#10069 and no errors found. Some notes from testing:
* tested both with and without i18n
* `JhiLanguageService` is now singleton (before every lazy loaded module had it's own version)
* translation keys are now loaded only once (before every lazy loaded module downloaded it's own version)
* `TranslateService` in `JhiAlertService` is now optional and is `null` in runtime if i18n is disabled, this is not problem because this is used only if `i18nEnabled=true`
* `JhiLanguageService` is now not used at all if i18n is disabled so no need to add `Optional` to `TranslateService`
* paging is working fine
* alert is working fine

ping @wmarques 
ping @vishal423 