### PR TITLE
Use explicit type in some places and polish test names

### DIFF
--- a/src/directive/sort.directive.ts
+++ b/src/directive/sort.directive.ts
@@ -27,13 +27,13 @@ export class JhiSortDirective {
     @Input() ascending: boolean;
     @Input() callback: Function;
 
-    @Output() predicateChange: EventEmitter<any> = new EventEmitter();
-    @Output() ascendingChange: EventEmitter<any> = new EventEmitter();
+    @Output() predicateChange: EventEmitter<string> = new EventEmitter();
+    @Output() ascendingChange: EventEmitter<boolean> = new EventEmitter();
 
     activeIconComponent: FaIconComponent;
     constructor() {}
 
-    sort(field: any) {
+    sort(field: string) {
         this.ascending = field !== this.predicate ? true : !this.ascending;
         this.predicate = field;
         this.predicateChange.emit(field);

--- a/src/service/alert.service.ts
+++ b/src/service/alert.service.ts
@@ -136,7 +136,7 @@ export class JhiAlertService {
         return alert;
     }
 
-    closeAlert(id: number, extAlerts?: JhiAlert[]): any {
+    closeAlert(id: number, extAlerts?: JhiAlert[]): JhiAlert[] {
         const thisAlerts: JhiAlert[] = extAlerts && extAlerts.length > 0 ? extAlerts : this.alerts;
         return this.closeAlertByIndex(thisAlerts.map(e => e.id).indexOf(id), thisAlerts);
     }

--- a/tests/directive/sort.directive.spec.ts
+++ b/tests/directive/sort.directive.spec.ts
@@ -15,8 +15,8 @@ import { JhiSortDirective } from '../../src/directive/sort.directive';
     `
 })
 class TestJhiSortDirectiveComponent {
-    predicate: any;
-    reverse: any;
+    predicate: string;
+    reverse: boolean;
     transition() {
     }
 }

--- a/tests/pipe/truncate-characters.pipe.spec.ts
+++ b/tests/pipe/truncate-characters.pipe.spec.ts
@@ -16,24 +16,21 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { JhiTruncateWordsPipe } from '../../src/pipe/truncate-words.pipe';
+import {JhiTruncateCharactersPipe} from '../../src/pipe/truncate-characters.pipe';
 
-describe('TruncateWordsPipe Tests', () => {
-    let pipe: JhiTruncateWordsPipe;
-    const input = 'Jhipster is the best';
+describe('TruncateCharactersPipe Tests', () => {
+
+    const input = 'jhipster test';
+    const chars = 12;
+    const breakOnWord = false;
+    let pipe: JhiTruncateCharactersPipe;
     beforeEach(() => {
-        pipe = new JhiTruncateWordsPipe();
+        pipe = new JhiTruncateCharactersPipe();
     });
 
-    it('Should return any', () => {
-        const words: any = -1;
-        const result = pipe.transform(input, words);
-        expect(result).toBe('');
-    });
+    it('Should return the first word', () => {
+        const result = pipe.transform(input, chars, breakOnWord);
 
-    it('Should return sentence', () => {
-        const words = 3;
-        const result = pipe.transform(input, words);
-        expect(result).toBe('Jhipster is the...');
+        expect(result).toEqual('jhipster...');
     });
 });

--- a/tests/pipe/truncate-words.pipe.spec.ts
+++ b/tests/pipe/truncate-words.pipe.spec.ts
@@ -16,21 +16,24 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import {JhiTruncateCharactersPipe} from '../../src/pipe/truncate-characters.pipe';
+import { JhiTruncateWordsPipe } from '../../src/pipe/truncate-words.pipe';
 
-describe('TruncateCharactersPipe Tests', () => {
-
-    const input = 'jhipster test';
-    const chars = 12;
-    const breakOnWord: any = false;
-    let pipe: JhiTruncateCharactersPipe;
+describe('TruncateWordsPipe Tests', () => {
+    let pipe: JhiTruncateWordsPipe;
+    const input = 'Jhipster is the best';
     beforeEach(() => {
-        pipe = new JhiTruncateCharactersPipe();
+        pipe = new JhiTruncateWordsPipe();
     });
 
-    it('Should return the first word', () => {
-        const result = pipe.transform(input, chars, breakOnWord);
+    it('Should return any', () => {
+        const words = -1;
+        const result = pipe.transform(input, words);
+        expect(result).toBe('');
+    });
 
-        expect(result).toEqual('jhipster...');
+    it('Should return sentence', () => {
+        const words = 3;
+        const result = pipe.transform(input, words);
+        expect(result).toBe('Jhipster is the...');
     });
 });


### PR DESCRIPTION
I tried to use explicit type as many places as possible but didn't gain a lot.  
But submitting what I could to do.

In **metrics** possible flow to define explicit types is:
* add metric DTO-s to https://github.com/jhipster/jhipster/tree/master/jhipster-framework/src/main/java/io/github/jhipster/config/metric and use them in `JHipsterMetricsEndpoint.java`
* auto generate Typescript types using https://github.com/vojtechhabarta/typescript-generator
* use generated types in `ng-jhipster` metrics

But currently I'm not planning to work with this metrics enhancement.