### PR TITLE
Remove init() from JhiLanguageService constructor

### DIFF
--- a/src/language/language.service.ts
+++ b/src/language/language.service.ts
@@ -27,9 +27,7 @@ import { JhiConfigService } from '../config.service';
 export class JhiLanguageService {
     currentLang = 'en';
 
-    constructor(private translateService: TranslateService, private configService: JhiConfigService) {
-        this.init();
-    }
+    constructor(private translateService: TranslateService, private configService: JhiConfigService) {}
 
     init() {
         const config = this.configService.getConfig();


### PR DESCRIPTION
`init()` will be executed from generated app constructor to avoid dependency injection issues caused by using HTTP interceptors in generated app.  
Related issue: jhipster/generator-jhipster#10476