### PR TITLE
Fix sort-by.directive icons

### DIFF
--- a/src/directive/sort-by.directive.ts
+++ b/src/directive/sort-by.directive.ts
@@ -44,7 +44,7 @@ export class JhiSortByDirective implements AfterContentInit {
 
     ngAfterContentInit(): void {
         if (this.jhiSort.predicate && this.jhiSort.predicate !== '_score' && this.jhiSort.predicate === this.jhiSortBy) {
-            this.updateIconDefinition(this.iconComponent, this.jhiSort.ascending ? this.sortDescIcon : this.sortAscIcon);
+            this.updateIconDefinition(this.iconComponent, this.jhiSort.ascending ? this.sortAscIcon : this.sortDescIcon);
             this.jhiSort.activeIconComponent = this.iconComponent;
         }
     }
@@ -54,7 +54,7 @@ export class JhiSortByDirective implements AfterContentInit {
         if (this.jhiSort.predicate && this.jhiSort.predicate !== '_score') {
             this.jhiSort.sort(this.jhiSortBy);
             this.updateIconDefinition(this.jhiSort.activeIconComponent, this.sortIcon);
-            this.updateIconDefinition(this.iconComponent, this.jhiSort.ascending ? this.sortDescIcon : this.sortAscIcon);
+            this.updateIconDefinition(this.iconComponent, this.jhiSort.ascending ? this.sortAscIcon : this.sortDescIcon);
             this.jhiSort.activeIconComponent = this.iconComponent;
         }
     }

--- a/tests/directive/sort-by.directive.spec.ts
+++ b/tests/directive/sort-by.directive.spec.ts
@@ -11,7 +11,7 @@ import { JhiSortByDirective, JhiSortDirective } from '../../src/directive';
     template: `
         <table>
             <thead>
-                <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
+                <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
                     <th jhiSortBy="name">ID<fa-icon [icon]="'sort'"></fa-icon></th>
                 </tr>
             </thead>
@@ -20,7 +20,7 @@ import { JhiSortByDirective, JhiSortDirective } from '../../src/directive';
 })
 class TestJhiSortByDirectiveComponent {
     predicate: string;
-    reverse: boolean;
+    ascending: boolean;
     constructor(library: FaIconLibrary) {
         library.addIconPacks(fas);
         library.addIcons(faSort, faSortDown, faSortUp);
@@ -87,7 +87,7 @@ describe('Directive: JhiSortByDirective', () => {
         // GIVEN
         spyOn(component, 'transition').and.callThrough();
         component.predicate = 'name';
-        component.reverse = true;
+        component.ascending = true;
         const sortDirective = tableRow.injector.get(JhiSortDirective);
         const sortByDirective = tableHead.injector.get(JhiSortByDirective);
 
@@ -97,11 +97,11 @@ describe('Directive: JhiSortByDirective', () => {
         // THEN
         expect(sortByDirective.jhiSortBy).toEqual('name');
         expect(component.predicate).toEqual('name');
-        expect(component.reverse).toEqual(true);
+        expect(component.ascending).toEqual(true);
         expect(sortByDirective.iconComponent).toBeDefined();
-        expect(sortByDirective.iconComponent.iconProp).toEqual(faSortDown);
+        expect(sortByDirective.iconComponent.iconProp).toEqual(faSortUp);
         expect(sortDirective.activeIconComponent).toBeDefined();
-        expect(sortDirective.activeIconComponent.iconProp).toEqual(faSortDown);
+        expect(sortDirective.activeIconComponent.iconProp).toEqual(faSortUp);
         expect(component.transition).toHaveBeenCalledTimes(0);
     });
 
@@ -109,7 +109,7 @@ describe('Directive: JhiSortByDirective', () => {
         // GIVEN
         spyOn(component, 'transition').and.callThrough();
         component.predicate = '_score';
-        component.reverse = true;
+        component.ascending = true;
         const sortDirective = tableRow.injector.get(JhiSortDirective);
         const sortByDirective = tableHead.injector.get(JhiSortByDirective);
 
@@ -121,7 +121,7 @@ describe('Directive: JhiSortByDirective', () => {
         // THEN
         expect(sortByDirective.jhiSortBy).toEqual('name');
         expect(component.predicate).toEqual('_score');
-        expect(component.reverse).toEqual(true);
+        expect(component.ascending).toEqual(true);
         expect(sortByDirective.iconComponent).toBeDefined();
         expect(sortByDirective.iconComponent.iconProp).toEqual('sort');
         expect(sortDirective.activeIconComponent).toBeUndefined();
@@ -132,7 +132,7 @@ describe('Directive: JhiSortByDirective', () => {
         // GIVEN
         spyOn(component, 'transition').and.callThrough();
         component.predicate = 'name';
-        component.reverse = true;
+        component.ascending = true;
         const sortDirective = tableRow.injector.get(JhiSortDirective);
         const sortByDirective = tableHead.injector.get(JhiSortByDirective);
 
@@ -143,11 +143,11 @@ describe('Directive: JhiSortByDirective', () => {
 
         // THEN
         expect(component.predicate).toEqual('name');
-        expect(component.reverse).toEqual(false);
+        expect(component.ascending).toEqual(false);
         expect(sortByDirective.iconComponent).toBeDefined();
-        expect(sortByDirective.iconComponent.iconProp).toEqual(faSortUp);
+        expect(sortByDirective.iconComponent.iconProp).toEqual(faSortDown);
         expect(sortDirective.activeIconComponent).toBeDefined();
-        expect(sortDirective.activeIconComponent.iconProp).toEqual(faSortUp);
+        expect(sortDirective.activeIconComponent.iconProp).toEqual(faSortDown);
         expect(component.transition).toHaveBeenCalledTimes(1);
     });
 
@@ -155,7 +155,7 @@ describe('Directive: JhiSortByDirective', () => {
         // GIVEN
         spyOn(component, 'transition').and.callThrough();
         component.predicate = 'name';
-        component.reverse = true;
+        component.ascending = true;
         const sortDirective = tableRow.injector.get(JhiSortDirective);
         const sortByDirective = tableHead.injector.get(JhiSortByDirective);
 
@@ -171,11 +171,11 @@ describe('Directive: JhiSortByDirective', () => {
 
         // THEN
         expect(component.predicate).toEqual('name');
-        expect(component.reverse).toEqual(true);
+        expect(component.ascending).toEqual(true);
         expect(sortByDirective.iconComponent).toBeDefined();
-        expect(sortByDirective.iconComponent.iconProp).toEqual(faSortDown);
+        expect(sortByDirective.iconComponent.iconProp).toEqual(faSortUp);
         expect(sortDirective.activeIconComponent).toBeDefined();
-        expect(sortDirective.activeIconComponent.iconProp).toEqual(faSortDown);
+        expect(sortDirective.activeIconComponent.iconProp).toEqual(faSortUp);
         expect(component.transition).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
Currently ascending ordering shows descending icon and descending ordering shows ascending icon. After these changes:
* ascending ordering shows ascending icon
* descending ordering shows descending icon

Issue was reported by jhipster/generator-jhipster#10629