### PR TITLE
Fix memory leak in jhiTranslate directive.

### DIFF
--- a/src/language/jhi-translate.directive.ts
+++ b/src/language/jhi-translate.directive.ts
@@ -18,10 +18,10 @@
  */
 import { Input, Directive, ElementRef, OnChanges, OnInit, Optional, OnDestroy } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-
-import { JhiConfigService } from '../config.service';
 import { ReplaySubject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+
+import { JhiConfigService } from '../config.service';
 
 /**
  * A wrapper directive on top of the translate pipe as the inbuilt translate directive from ngx-translate is too verbose and buggy


### PR DESCRIPTION
The directive subscribes to the `onLangChange` observable of the
TranslateService but never unsubscribes. This keeps the nodes
the directive is used on in memory indefinitely, even if they have been
removed from the DOM.

If you take a heap snapshot with the Chrome dev tools, there are quite a few detached nodes that are still referenced by the subscription to `onLangChange`.
![image](https://user-images.githubusercontent.com/440914/68653848-e82a2f00-052c-11ea-9d32-2d784e403fb4.png)

I made sure to unsubscribe from the observable when the directive is destroyed to avoid this leak.
