### PR TITLE
Support simple notifications without content, make JhiEventManager st…

### DIFF
--- a/src/service/event-with-content.model.ts
+++ b/src/service/event-with-content.model.ts
@@ -16,12 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-export * from './pagination-util.service';
-export * from './parse-links.service';
-export * from './data-util.service';
-export * from './date-util.service';
-export * from './event-manager.service';
-export * from './event-with-content.model';
-export * from './alert.service';
-export * from './base64.service';
-export * from './resolve-paging-params.service';
+export class JhiEventWithContent<T> {
+    constructor(public name: string, public content: T) {}
+}


### PR DESCRIPTION
…rongly typed and simplify subscription

After releasing this we can change `generator-jhipster` to use this new API.

This allows to make code generated by `generator-jhipster` simpler and easier to understand.

I came to that while dealing with jhipster/generator-jhipster#10631

If someone is using `JhiEventManager` in the custom code with using content then this is a breaking change for that custom code. But adaption to new API is very simple: in custom code can just avoid calling response.content, because response is already content.

https://semver.org/ says: Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

So as we are at 0.y.z then we don't violate semver.

But if you think that it's better not to make breaking changes then I can just add support to simple string events without content by changing `filter` in `subscribe`, instead of
```
                filter(event => {
                    return event.name === eventName;
                })
```
use
```
                filter(event => {
                    if (typeof event === 'string') {
                        return event === eventName;
                    }
                    return event.name === eventName;
                })
```
