### PR TITLE
Prepare to remove promises

### DIFF
--- a/src/language/language.service.ts
+++ b/src/language/language.service.ts
@@ -29,20 +29,27 @@ export class JhiLanguageService {
 
     constructor(private translateService: TranslateService, private configService: JhiConfigService) {}
 
-    init() {
+    init(): void {
         const config = this.configService.getConfig();
         this.currentLang = config.defaultI18nLang;
         this.translateService.setDefaultLang(this.currentLang);
         this.translateService.use(this.currentLang);
     }
 
-    changeLanguage(languageKey: string) {
+    changeLanguage(languageKey: string): void {
         this.currentLang = languageKey;
         this.configService.CONFIG_OPTIONS.defaultI18nLang = languageKey;
         this.translateService.use(this.currentLang);
     }
 
+    /**
+     * @deprecated Will be removed when releasing generator-jhipster v7
+     */
     getCurrent(): Promise<string> {
         return Promise.resolve(this.currentLang);
+    }
+
+    getCurrentLanguage(): string {
+        return this.currentLang;
     }
 }

--- a/src/service/data-util.service.ts
+++ b/src/service/data-util.service.ts
@@ -158,7 +158,7 @@ export class JhiDataUtils {
                 const file: File = eventTarget.files[0];
                 if (isImage && !file.type.startsWith('image/')) {
                     const error: JhiFileLoadError = {
-                        message: `File was expected to be an image but was found to be ${file.type}`,
+                        message: `File was expected to be an image but was found to be '${file.type}'`,
                         key: 'not.image',
                         params: { fileType: file.type }
                     };
@@ -176,7 +176,7 @@ export class JhiDataUtils {
                 }
             } else {
                 const error: JhiFileLoadError = {
-                    message: `Base64 data was not set as file could not be extracted from passed parameter: ${event}`,
+                    message: 'Could not extract file',
                     key: 'could.not.extract',
                     params: { event }
                 };


### PR DESCRIPTION
jhipster/generator-jhipster#10383 removed promises from the most of the places, this PR is preparation to remove promises from all JHipster specific code in the generator-jhipster Angular part.

`JhiLanguageService` - string field getter as promise that resolves immediately is pointless, so marked `Promise` getter as deprecated and added simple string getter.

`JhiDataUtils` - method `setFileData` is orphan in the sense of the generator-jhipster, this is not used in the generator-jhipster any more, but this was planned to rewrite and use according to this comment: https://github.com/jhipster/generator-jhipster/pull/9153#discussion_r252805435 so:
* I added new `Observable` and `FormGroup` specific method `loadFileToForm`
* should we deprecated old orphan method `setFileData` and remove this when generator-jhipster v7 is released (to remove code what is not needed for generator-jhipster)?

This is a second PR for the code quality. I started with #115 which is for the jhipster/generator-jhipster#10631. I would like to merge this and #115 and then need a new release to use that in the generator-jhipster for the code quality impovements.
